### PR TITLE
Fix: attach listeners before calling handler

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,9 +33,9 @@ export function defineExpressHandler(handler: RequestHandler) {
         ereq.res = eres
         eres.req = ereq
         ereq.next = next
-        handler(ereq, eres, next)
         eres.once('close', next)
         eres.once('error', next)
+        handler(ereq, eres, next)
       } catch (err) {
         next(err as Error)
       }


### PR DESCRIPTION
really great helper to ease migration to Nuxt 3 without doing everything at once!
I noticed that in some cases, during SSR the route too quickly fires `close` so that `next` is never called, resulting in a very unpleasant hanging. At least for my situation, adding the handlers before solves this issue